### PR TITLE
Changed kaminari dependency minimum version

### DIFF
--- a/liquid-rails.gemspec
+++ b/liquid-rails.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rails',    '>= 3.2'
   spec.add_dependency 'liquid',   '>= 3.0.0'
-  spec.add_dependency 'kaminari', '~> 0.16.1'
+  spec.add_dependency 'kaminari', '>= 0.16.1'
 end


### PR DESCRIPTION
Because I needed access to a Kaminari feature that was after version 0.16 (speficially, the `params_on_first_page` option), I changed the gemspec to no longer use a pessimistic version constraint.

As far as I can tell this does not break anything in liquid-rails, but I did not do very rigorous testing yet.
